### PR TITLE
fix a typo

### DIFF
--- a/Get-ChildItemColor.psm1
+++ b/Get-ChildItemColor.psm1
@@ -4,7 +4,7 @@ $CompressedList = @(".7z", ".gz", ".rar", ".tar", ".zip")
 $ExecutableList = @(".exe", ".bat", ".cmd", ".py", ".pl", ".ps1",
                     ".psm1", ".vbs", ".rb", ".reg", ".fsx", ".sh")
 $DllPdbList = @(".dll", ".pdb")
-$TextList = @(".csv", ".log", "markdown", ".rst", ".txt")
+$TextList = @(".csv", ".log", ".markdown", ".rst", ".txt")
 $ConfigsList = @(".cfg", ".conf", ".config", ".ini", ".json")
 
 $ColorTable = @{}


### PR DESCRIPTION
I find a minor typo. 
A dot should be added for `markdown` suffix. Otherwise `$ColorTable.ContainsKey($Item.Extension)` will fail the test.