### PR TITLE
Fallback to Gray when no OriginalForegroundColor

### DIFF
--- a/Get-ChildItemColor.psm1
+++ b/Get-ChildItemColor.psm1
@@ -1,4 +1,5 @@
 $OriginalForegroundColor = $Host.UI.RawUI.ForegroundColor
+if ([System.Enum]::IsDefined([System.ConsoleColor], 1) -eq "False") { $OriginalForegroundColor = "Gray" }
 
 $CompressedList = @(".7z", ".gz", ".rar", ".tar", ".zip")
 $ExecutableList = @(".exe", ".bat", ".cmd", ".py", ".pl", ".ps1",


### PR DESCRIPTION
While using the NuGet Console in Visual Studio I got errors when listing directory contents. It was because somehow the $Host.UI.RawUI.ForegroundColor was = -1. I don't know how often this situation arises, but the fix above makes everything work on my system. Essentially we're using some .NET code to ensure the value in the ForegroundColor property is a valid ConsoleColor. If not we simply use "Gray".