### PR TITLE
Removing additional newline for Get-ChildItemColorWide

### DIFF
--- a/Get-ChildItemColor.psm1
+++ b/Get-ChildItemColor.psm1
@@ -136,7 +136,6 @@ Function Get-ChildItemColorFormatWide {
 
     If ($nnl) {  # conditionally add an empty line
         Write-Host ""
-        Write-Host ""
     }
 }
 


### PR DESCRIPTION
Addressing #17 

Tested on varying sizes of console with varying numbers and types of files. 