### PR TITLE
Fix error when omitting string and support powershell v6

### DIFF
--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -57,8 +57,8 @@ Function Get-ChildItemColorFormatWide {
 
     $Items = Invoke-Expression $Expression
 
-    $lnStr = $Items | Select-Object Name | Sort-Object { $Host.UI.RawUI.LengthInBufferCells("$_") } -Descending | Select-Object -First 1
-    $len = $Host.UI.RawUI.LengthInBufferCells($lnStr.Name)
+    $lnStr = $Items | Select-Object Name | Sort-Object { LengthInBufferCells("$_") } -Descending | Select-Object -First 1
+    $len = LengthInBufferCells($lnStr.Name)
     $width = $Host.UI.RawUI.WindowSize.Width
     $cols = If ($len) {[math]::Floor(($width + 1) / ($len + 2))} Else {1}
     if (!$cols) {$cols = 1}
@@ -106,12 +106,14 @@ Function Get-ChildItemColorFormatWide {
 
         # truncate the item name
         $toWrite = $Item.Name
-        If ($Host.UI.RawUI.LengthInBufferCells($toWrite) -gt $pad) {
+        $itemLength = LengthInBufferCells($toWrite)
+        If ($itemLength -gt $pad) {
             $toWrite = (CutString $toWrite $pad)
+            $itemLength = LengthInBufferCells($toWrite)
         }
 
         $Color = Get-FileColor $Item
-        $widePad = $pad - ($Host.UI.RawUI.LengthInBufferCells($toWrite) - $toWrite.Length)
+        $widePad = $pad - ($itemLength - $toWrite.Length)
         Write-Host ("{0,-$widePad}" -f $toWrite) -Fore $Color -NoNewLine:$nnl
 
         If ($nnl) {

--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -107,7 +107,7 @@ Function Get-ChildItemColorFormatWide {
         # truncate the item name
         $toWrite = $Item.Name
         If ($Host.UI.RawUI.LengthInBufferCells($toWrite) -gt $pad) {
-            $toWrite = $toWrite.Substring(0, $pad - 3) + "..."
+            $toWrite = (CutString $toWrite $pad)
         }
 
         $Color = Get-FileColor $Item

--- a/src/PSColorHelper.ps1
+++ b/src/PSColorHelper.ps1
@@ -3,9 +3,17 @@ function CutString
 {
     param ([string]$Message, $length)
 
-    if ($Message.length -gt $length)
+    $len = 0
+    $count = 0
+    $max = $length - 3
+    ForEach ($c in $Message.ToCharArray())
     {
-        return $Message.SubString(0, $length-3) + '...'
+        $len += $Host.UI.RawUI.LengthInBufferCells($c)
+        if ($len -gt $max)
+        {
+            Return $Message.SubString(0, $count) + '...'
+        }
+        $count++
     }
 
     Return $Message

--- a/src/PSColorHelper.ps1
+++ b/src/PSColorHelper.ps1
@@ -8,13 +8,56 @@ function CutString
     $max = $length - 3
     ForEach ($c in $Message.ToCharArray())
     {
-        $len += $Host.UI.RawUI.LengthInBufferCells($c)
+        $len += LengthInBufferCell($c)
         if ($len -gt $max)
         {
             Return $Message.SubString(0, $count) + '...'
         }
         $count++
     }
-
     Return $Message
+}
+
+function LengthInBufferCells
+{
+    param ([string]$Str)
+
+    $len = 0
+    ForEach ($c in $Str.ToCharArray())
+    {
+        $len += LengthInBufferCell($c)
+    }
+    Return $len
+}
+
+
+function LengthInBufferCell
+{
+    param ([char]$Char)
+    # The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
+    # which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
+    [bool]$isWide = $Char -ge 0x1100 -and
+        ($Char -le 0x115f -or # Hangul Jamo init. consonants
+         $Char -eq 0x2329 -or $Char -eq 0x232a -or
+         ([uint32]($Char - 0x2e80) -le (0xa4cf - 0x2e80) -and
+          $Char -ne 0x303f) -or # CJK ... Yi
+         ([uint32]($Char - 0xac00) -le (0xd7a3 - 0xac00)) -or # Hangul Syllables
+         ([uint32]($Char - 0xf900) -le (0xfaff - 0xf900)) -or # CJK Compatibility Ideographs
+         ([uint32]($Char - 0xfe10) -le (0xfe19 - 0xfe10)) -or # Vertical forms
+         ([uint32]($Char - 0xfe30) -le (0xfe6f - 0xfe30)) -or # CJK Compatibility Forms
+         ([uint32]($Char - 0xff00) -le (0xff60 - 0xff00)) -or # Fullwidth Forms
+         ([uint32]($Char - 0xffe0) -le (0xffe6 - 0xffe0)))
+
+    # We can ignore these ranges because .Net strings use surrogate pairs
+    # for this range and we do not handle surrogage pairs.
+    # ($Char -ge 0x20000 -and $Char -le 0x2fffd) -or
+    # ($Char -ge 0x30000 -and $Char -le 0x3fffd)
+    if ($isWide)
+    {
+        Return 2
+    }
+    else
+    {
+        Return 1
+    }
 }


### PR DESCRIPTION
Fixed incorrect calculation of the second argument of `SubString` when omitting long filenames with 3 dots.
Also, ported `LengthInBufferCells` to work with PowerShell v6.

**error**
![image](https://user-images.githubusercontent.com/1295639/77355570-02500580-6d88-11ea-90a6-00c05b6d5b57.png)

**fixed**
![image](https://user-images.githubusercontent.com/1295639/77355590-0845e680-6d88-11ea-9ab9-588750449046.png)

**support powershell v6**
![image](https://user-images.githubusercontent.com/1295639/77355617-172c9900-6d88-11ea-870a-43cdb5abca27.png)
