### PR TITLE
Fix uint32 error in cell width calculation

### DIFF
--- a/src/PSColorHelper.ps1
+++ b/src/PSColorHelper.ps1
@@ -34,19 +34,19 @@ function LengthInBufferCells
 function LengthInBufferCell
 {
     param ([char]$Char)
-    # The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
+    # The following is based on https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
     # which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
     [bool]$isWide = $Char -ge 0x1100 -and
         ($Char -le 0x115f -or # Hangul Jamo init. consonants
          $Char -eq 0x2329 -or $Char -eq 0x232a -or
-         ([uint32]($Char - 0x2e80) -le (0xa4cf - 0x2e80) -and
-          $Char -ne 0x303f) -or # CJK ... Yi
-         ([uint32]($Char - 0xac00) -le (0xd7a3 - 0xac00)) -or # Hangul Syllables
-         ([uint32]($Char - 0xf900) -le (0xfaff - 0xf900)) -or # CJK Compatibility Ideographs
-         ([uint32]($Char - 0xfe10) -le (0xfe19 - 0xfe10)) -or # Vertical forms
-         ([uint32]($Char - 0xfe30) -le (0xfe6f - 0xfe30)) -or # CJK Compatibility Forms
-         ([uint32]($Char - 0xff00) -le (0xff60 - 0xff00)) -or # Fullwidth Forms
-         ([uint32]($Char - 0xffe0) -le (0xffe6 - 0xffe0)))
+         ($Char -ge 0x2e80 -and $Char -le 0xa4cf -and
+         $Char -ne 0x303f) -or # CJK ... Yi
+         ($Char -ge 0xac00 -and $Char -le 0xd7a3) -or # Hangul Syllables
+         ($Char -ge 0xf900 -and $Char -le 0xfaff) -or # CJK Compatibility Ideographs
+         ($Char -ge 0xfe10 -and $Char -le 0xfe19) -or # Vertical forms
+         ($Char -ge 0xfe30 -and $Char -le 0xfe6f) -or # CJK Compatibility Forms
+         ($Char -ge 0xff00 -and $Char -le 0xff60) -or # Fullwidth Forms
+         ($Char -ge 0xffe0 -and $Char -le 0xffe6))
 
     # We can ignore these ranges because .Net strings use surrogate pairs
     # for this range and we do not handle surrogage pairs.


### PR DESCRIPTION
This fixes issue #38.  It was tested on Powershell Core 7.2.2 and Powershell Desktop 5.1.22000.613 and appears to work on both.