### PR TITLE
Allow RegEx ; added GetChildItemColorRegExTable

### DIFF
--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -136,7 +136,6 @@ function Get-ChildItemColorFormatWide {
             }
 
             $color = Get-FileColor $item
-            Add-Content -Path "C:\Users\Michel\AppData\Local\Temp\x.txt" -Value "Get-ChildItemColorFormatWide Get-FileColor $item"
             $widePad = $pad - ($itemLength - $toWrite.Length)
             Write-Host ("{0,-$widePad}" -f $toWrite) -Fore $color -NoNewLine:$nnl
 

--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -28,6 +28,22 @@ function Get-FileColor($item) {
     }
 
     $Color = $GetChildItemColorTable.File[$key]
+    
+    
+    $keyRegex = ""
+    
+    if ($key -ne 'Symlink') {
+    	foreach ($regex in $GetChildItemColorRegExTable.File.Keys) {
+        	if ($item.Name -match $regex) {
+         		$keyRegex = $regex
+        	}
+        } 
+    }
+    if ($keyRegex -ne "") {
+    	$Color = $GetChildItemColorRegExTable.File[$keyRegex]
+    }
+    
+    
     return $Color
 }
 
@@ -120,6 +136,7 @@ function Get-ChildItemColorFormatWide {
             }
 
             $color = Get-FileColor $item
+            Add-Content -Path "C:\Users\Michel\AppData\Local\Temp\x.txt" -Value "Get-ChildItemColorFormatWide Get-FileColor $item"
             $widePad = $pad - ($itemLength - $toWrite.Length)
             Write-Host ("{0,-$widePad}" -f $toWrite) -Fore $color -NoNewLine:$nnl
 

--- a/src/Get-ChildItemColorTable.ps1
+++ b/src/Get-ChildItemColorTable.ps1
@@ -1,5 +1,11 @@
 $global:GetChildItemColorExtensions = @{}
 
+$global:GetChildItemColorRegExTable = @{
+    File = @{ Default = $OriginalForegroundColor }
+}
+# starts with dot
+$GetChildItemColorRegExTable.File.Add('^[.]','DarkRed')
+
 $GetChildItemColorExtensions.Add(
     'CompressedList',
     @(


### PR DESCRIPTION
This pull request adds a new table called GetChildItemColorRegExTable to allow colorization of file names based on a regex. ServiceController not updated, only File (add pattern 'starts with dot ^[.]')