### PR TITLE
Allow RegEx ; added GetChildItemColorRegExTable ; test for file attributes

### DIFF
--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -19,8 +19,12 @@ function Get-FileColor($item) {
 
     if ([bool]($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -and (-not $inOneDrive)) {
         $key = 'Symlink'
-    } elseif ($item.GetType().Name -eq 'DirectoryInfo') {
-        $key = 'Directory'
+    } elseif ($item.IsReadOnly) {
+        $key = 'ReadOnly'
+	} elseif ($item.Attributes -band [System.IO.FileAttributes]::Hidden) {
+        $key = 'Hidden'
+    } elseif ($item.Attributes -band [System.IO.FileAttributes]::System) {
+        $key = 'System'
     } elseif ($item.PSobject.Properties.Name -contains "Extension") {
         If ($GetChildItemColorTable.File.ContainsKey($item.Extension)) {
             $key = $item.Extension

--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -28,6 +28,22 @@ function Get-FileColor($item) {
     }
 
     $Color = $GetChildItemColorTable.File[$key]
+    
+    
+    $keyRegex = ""
+    
+    if ($key -ne 'Symlink') {
+    	foreach ($regex in $GetChildItemColorRegExTable.File.Keys) {
+        	if ($item.Name -match $regex) {
+         		$keyRegex = $regex
+        	}
+        } 
+    }
+    if ($keyRegex -ne "") {
+    	$Color = $GetChildItemColorRegExTable.File[$keyRegex]
+    }
+    
+    
     return $Color
 }
 

--- a/src/Get-ChildItemColorTable.ps1
+++ b/src/Get-ChildItemColorTable.ps1
@@ -1,5 +1,11 @@
 $global:GetChildItemColorExtensions = @{}
 
+$global:GetChildItemColorRegExTable = @{
+    File = @{ Default = $OriginalForegroundColor }
+}
+# starts with dot
+$GetChildItemColorRegExTable.File.Add('^[.]','DarkRed')
+
 $GetChildItemColorExtensions.Add(
     'CompressedList',
     @(

--- a/src/Get-ChildItemColorTable.ps1
+++ b/src/Get-ChildItemColorTable.ps1
@@ -1,8 +1,10 @@
 $global:GetChildItemColorExtensions = @{}
+$global:GetChildItemColorProps = @{}
 
 $global:GetChildItemColorRegExTable = @{
     File = @{ Default = $OriginalForegroundColor }
 }
+
 # starts with dot
 $GetChildItemColorRegExTable.File.Add('^[.]','DarkRed')
 
@@ -174,6 +176,10 @@ $global:GetChildItemColorTable = @{
     Match = @{ Default = $OriginalForegroundColor }
 }
 
+#$GetChildItemColorTable.File.Add('Archive',"DarkRed")
+$GetChildItemColorTable.File.Add('Hidden',"DarkRed")
+$GetChildItemColorTable.File.Add('System',"DarkRed")
+$GetChildItemColorTable.File.Add('ReadOnly',"DarkRed")
 $GetChildItemColorTable.File.Add('Directory', "Blue")
 $GetChildItemColorTable.File.Add('Symlink', "Cyan") 
 


### PR DESCRIPTION
This pull request adds a new table called GetChildItemColorRegExTable to allow colorization of file names based on a regex. ServiceController not updated, only File (add pattern 'starts with dot ^[.]')


Test for hidden or system files ; added styles for those