### PR TITLE
Get-ChildItem compatibility and Unix-style size output

### DIFF
--- a/src/FileInfo.ps1
+++ b/src/FileInfo.ps1
@@ -1,18 +1,20 @@
 # Helper method to write file length in a more human readable format
+# Will output the length in B, KB, MB, or GB
+# Similar to the `ls -lh` command in Unix, it'll truncate any trailing zeros after the decimal point
 function Write-FileLength {
     Param ($Length)
 
-    If ($Length -eq $null) {
+    If ($null -eq $Length) {
         Return ""
     } ElseIf ($Length -ge 1GB) {
-        Return ($Length / 1GB).ToString("F") + 'GB'
+        Return ($Length / 1GB).ToString("#0.#") + 'G'
     } ElseIf ($Length -ge 1MB) {
-        Return ($Length / 1MB).ToString("F") + 'MB'
+        Return ($Length / 1MB).ToString("#0.#") + 'M'
     } ElseIf ($Length -ge 1KB) {
-        Return ($Length / 1KB).ToString("F") + 'KB'
+        Return ($Length / 1KB).ToString("#0.#") + 'K'
     }
 
-    Return $Length.ToString() + '  '
+    Return $Length.ToString()
 }
 
 # Outputs a line of a DirectoryInfo or FileInfo

--- a/src/FileInfo.ps1
+++ b/src/FileInfo.ps1
@@ -17,18 +17,30 @@ function Write-FileLength {
 
 # Outputs a line of a DirectoryInfo or FileInfo
 function Write-Color-LS {
-    param ([string]$color = "White", $item)
+    param ([string]$color = "White", [bool]$humanReadable, $item)
 
     Write-host ("{0,-7} " -f $item.mode) -NoNewline
     Write-host ("{0,25} " -f ([String]::Format("{0,10}  {1,8}", $item.LastWriteTime.ToString("d"), $item.LastWriteTime.ToString("t")))) -NoNewline
-    Write-host ("{0,10} " -f (Write-FileLength $item.length)) -NoNewline
+    # Do not write length 1 for directories
+    if ($item.PSIsContainer) {
+        Write-host ("{0,10} " -f " ") -NoNewLine
+    } else {
+        # Write length in human readable format if the switch is set
+        if ($humanReadable) {
+            Write-host ("{0,10} " -f (Write-FileLength $item.length)) -NoNewline
+        } else {
+        Write-host ("{0,10} " -f $item.length) -NoNewline
+        }
+    }
     Write-host ("{0}" -f $item.name) -ForegroundColor $color
 }
 
 function FileInfo {
     param (
         [Parameter(Mandatory=$True, Position=1)]
-        $item
+        $item,
+        [switch]$HumanReadableSize
+
     )
 
     $parentName = $item.PSParentPath.Replace("Microsoft.PowerShell.Core\FileSystem::", "")
@@ -52,7 +64,7 @@ function FileInfo {
 
     $color = Get-FileColor $item
 
-    Write-Color-LS $color $item
+    Write-Color-LS $color $HumanReadableSize $item
 
     $Script:LastParentName = $parentName
 }

--- a/src/FileInfo.ps1
+++ b/src/FileInfo.ps1
@@ -5,21 +5,22 @@ function Write-FileLength {
     Param ($Length)
 
     If ($null -eq $Length) {
-        Return ""
+        Return "", (Get-SizeColor "")
     } ElseIf ($Length -ge 1GB) {
-        Return ($Length / 1GB).ToString("#0.#") + 'G'
+        Return (($Length / 1GB).ToString("#0.#") + 'G'), (Get-SizeColor "G")
     } ElseIf ($Length -ge 1MB) {
-        Return ($Length / 1MB).ToString("#0.#") + 'M'
+        Return (($Length / 1MB).ToString("#0.#") + 'M'), (Get-SizeColor "M")
     } ElseIf ($Length -ge 1KB) {
-        Return ($Length / 1KB).ToString("#0.#") + 'K'
+        Return (($Length / 1KB).ToString("#0.#") + 'K'), (Get-SizeColor "K")
     }
 
-    Return $Length.ToString()
+    # For bytes
+    Return $Length.ToString(), (Get-SizeColor "B")
 }
 
 # Outputs a line of a DirectoryInfo or FileInfo
 function Write-Color-LS {
-    param ([string]$color = "White", [bool]$humanReadable, $item)
+    param ([string]$fileColor = "White", [bool]$humanReadable, $item)
 
     Write-host ("{0,-7} " -f $item.mode) -NoNewline
     Write-host ("{0,25} " -f ([String]::Format("{0,10}  {1,8}", $item.LastWriteTime.ToString("d"), $item.LastWriteTime.ToString("t")))) -NoNewline
@@ -29,12 +30,13 @@ function Write-Color-LS {
     } else {
         # Write length in human readable format if the switch is set
         if ($humanReadable) {
-            Write-host ("{0,10} " -f (Write-FileLength $item.length)) -NoNewline
+            $sizeAndColor = Write-FileLength $item.length
+            Write-host ("{0,10} " -f $sizeAndColor[0]) -NoNewline -ForegroundColor $sizeAndColor[1]
         } else {
         Write-host ("{0,10} " -f $item.length) -NoNewline
         }
     }
-    Write-host ("{0}" -f $item.name) -ForegroundColor $color
+    Write-host ("{0}" -f $item.name) -ForegroundColor $fileColor
 }
 
 function FileInfo {

--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -154,11 +154,15 @@ function Out-ChildItemColor {
     [CmdletBinding(HelpUri='http://go.microsoft.com/fwlink/?LinkID=113362', RemotingCapability='None')]
     param(
         [switch] ${Transcript},
+        [switch] ${HumanReadableSize},
         [Parameter(Position=0, ValueFromPipeline=$True)]  [psobject]  ${InputObject}
     )
 
     begin {
         try {
+            if($PSBoundParameters.ContainsKey('HumanReadableSize')) {
+                $PSBoundParameters.Remove('HumanReadableSize') | Out-Null
+            }
             for ($l=1; $l -lt $GetChildItemColorVerticalSpace; $l++) {
                 Write-Host ""
             }
@@ -180,7 +184,7 @@ function Out-ChildItemColor {
     process {
         try {
             if (($_ -is [System.IO.DirectoryInfo]) -or ($_ -is [System.IO.FileInfo])) {
-                FileInfo $_
+                FileInfo $_ -HumanReadableSize:$HumanReadableSize
                 $_ = $Null
             }
 
@@ -254,12 +258,19 @@ param(
     ${Force},
 
     [switch]
-    ${Name})
+    ${Name},
+
+    [Alias('-h')]
+    [switch]
+    ${HumanReadableSize} = $false)
 
 
 dynamicparam
 {
     try {
+        if($PSBoundParameters.ContainsKey('HumanReadableSize')) {
+            $PSBoundParameters.Remove('HumanReadableSize') | Out-Null
+        }
         $targetCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Management\Get-ChildItem', [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
         $dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object { $_.Value.IsDynamic })
         if ($dynamicParams.Length -gt 0)
@@ -315,7 +326,7 @@ process
         if ($ifPipeline) {
             $steppablePipeline.Process($_)
         } else {
-            $items | Out-ChildItemColor
+            $items | Out-ChildItemColor -HumanReadableSize:$HumanReadableSize
         }
     } catch {
         throw

--- a/src/Get-ChildItemColor.psm1
+++ b/src/Get-ChildItemColor.psm1
@@ -5,6 +5,13 @@ $Global:GetChildItemColorVerticalSpace = 1
 
 . "$PSScriptRoot\Get-ChildItemColorTable.ps1"
 
+function Get-SizeColor($sizeKey) {
+    if ($null -eq $sizeKey -or $sizeKey -eq "") {
+        $sizeKey = 'Default'
+    }
+    return $GetChildItemColorTable.Size[$sizeKey]
+}
+
 function Get-FileColor($item) {
     $key = 'Default'
 

--- a/src/Get-ChildItemColorTable.ps1
+++ b/src/Get-ChildItemColorTable.ps1
@@ -166,6 +166,7 @@ $global:GetChildItemColorTable = @{
     File = @{ Default = $OriginalForegroundColor }
     Service = @{ Default = $OriginalForegroundColor }
     Match = @{ Default = $OriginalForegroundColor }
+    Size = @{Default = $OriginalForegroundColor}
 }
 
 $GetChildItemColorTable.File.Add('Directory', "Blue")
@@ -201,3 +202,9 @@ $GetChildItemColorTable.Service.Add('Stopped', "DarkRed")
 $GetChildItemColorTable.Match.Add('Path', "Cyan")
 $GetChildItemColorTable.Match.Add('LineNumber', "Yellow")
 $GetChildItemColorTable.Match.Add('Line', $OriginalForegroundColor)
+
+$GetChildItemColorTable.Size.Add('K', "DarkGreen")
+$GetChildItemColorTable.Size.Add('M', "DarkYellow")
+$GetChildItemColorTable.Size.Add('G', "DarkRed")
+$GetChildItemColorTable.Size.Add('B', $OriginalForegroundColor)
+


### PR DESCRIPTION
> Thank you for this Awesome module! I've very much enjoyed using this! Here is some of my improvements, hope you'll find them useful

This PR adds the following functionalities:

- Output compatibility with `Get-ChildItem` (see the issue below)
  - Drop-in replacement for `Get-ChildItem` (same output in bytes except color added)
  - Fixes right alignment when outputting human-readable size
- Unix `ls -h` style formatting
  - Adds `-h` and `-HumanReadableSize` flag 
  - Unix style size string (e.g. `M` instead of `MB`, `K` instead of `KB` etc)
  - Use single point precision and remove trailing zeros after decimal point
- Adds color to the size column (DarkGreen for KB, DarkYellow for MB and DarkRed for GB)

Before:
> cmd: `Get-ChildItemColor`
![image](https://github.com/user-attachments/assets/b02191b0-2803-44b0-9843-b556e6014f1f)

After:
>cmd: `Get-ChildItemColor`
![image](https://github.com/user-attachments/assets/659f7ab6-a626-4ea6-a3c3-f299cac340f6)

>cmd: `Get-ChildItemColor -h` or `Get-ChildItemColor -HumanReadableSize`
![image](https://github.com/user-attachments/assets/1f9bd64f-6e91-4aa5-a691-9c9e021d6cbd)

## Issues Closed or Referenced

- Closes #56
- References #48 

## Issues Closed or Referenced

- Closes #56
- References #48 